### PR TITLE
call to it caused infinite loop in global build

### DIFF
--- a/lib/ember-mocha/it.js
+++ b/lib/ember-mocha/it.js
@@ -5,9 +5,10 @@ function resetViews() {
   Ember.View.views = {};
 }
 
+var originalIt = window.it;
 export default function(testName, callback) {
   var wrapper;
-  
+
   if (callback.length === 1) {
     wrapper = function(done) {
       resetViews();
@@ -20,5 +21,5 @@ export default function(testName, callback) {
     };
   }
 
-  it(testName, wrapper);
+  originalIt(testName, wrapper);
 }


### PR DESCRIPTION
In the global build, the `it` function contained a reference to
itself. Instead capture reference to the original `it` for calling.
