### PR TITLE
allow `it` and `xit` forms in specs.

### DIFF
--- a/lib/ember-mocha/it.js
+++ b/lib/ember-mocha/it.js
@@ -7,8 +7,10 @@ function resetViews() {
 
 export default function(testName, callback) {
   var wrapper;
-  
-  if (callback.length === 1) {
+
+  if (!callback) {
+    wrapper = null;
+  } else if (callback.length === 1) {
     wrapper = function(done) {
       resetViews();
       return callback.call(getContext(), done);

--- a/tests/it-test.js
+++ b/tests/it-test.js
@@ -25,4 +25,19 @@ describe('it', function() {
       }, 10);
     });
   });
+  var pendingError;
+  try {
+    it('can have a pending spec');
+  } catch (e) {
+    pendingError = e;
+  }
+  it('does not throw errors when you mark a pending spec', function() {
+    expect(pendingError).to.be.undefined;
+    var pendingSpec = mocha.suite.suites.find(function(suite) {
+      return suite.tests.find(function(test) {
+        return test.title  == 'can have a pending spec';
+      });
+    });
+    expect(pendingSpec).to.be.ok;
+  });
 });


### PR DESCRIPTION
Mocha allows calling `it()` with only a test title, which is the syntax
it uses for marking a spec as pending. `xit` delegates to `it` and does
not pass along any callback.
