### PR TITLE
allow `it`, `xit`, `it.skip` and `it.only` forms.

### DIFF
--- a/lib/ember-mocha/it.js
+++ b/lib/ember-mocha/it.js
@@ -26,7 +26,7 @@ function wrap(specifier) {
     }
     specifier(testName, wrapper);
   };
-};
+}
 
 var wrappedIt = wrap(window.it);
 wrappedIt.only = wrap(window.it.only);

--- a/tests/it-test.js
+++ b/tests/it-test.js
@@ -10,7 +10,9 @@ function tryMochaSpecifier(fn) {
   } catch (e) {
     return e;
   }
-};
+}
+
+var Mocha = window.mocha;
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -56,8 +58,8 @@ describe('it', function() {
   var originalMochaGrep;
   var mochaGrep;
   it.only('runs this test', function() {});
-  mochaGrep = mocha.options.grep;
-  mocha.options.grep = originalMochaGrep;
+  mochaGrep = Mocha.options.grep;
+  Mocha.options.grep = originalMochaGrep;
 
 
   var skippedError = tryMochaSpecifier(function() {
@@ -66,7 +68,7 @@ describe('it', function() {
 
   it('skips tests with the .skip modifier', function() {
     expect(skippedError).to.be.null;
-    var pendingSpec = window.mocha.suite.suites.find(function(suite) {
+    var pendingSpec = Mocha.suite.suites.find(function(suite) {
       return suite.tests.find(function(test) {
         return test.title === 'a skipped spec';
       });


### PR DESCRIPTION
Mocha allows calling `it()` with only a test title, which is the syntax
it uses for marking a spec as pending. `xit` delegates to `it` and does
not pass along any callback. It also supports using `it.skip()` to mark
a particular test as pending.

Another modifier for tests is `it.only()` which causes the test runner
to only run that single test for the next run.
