### PR TITLE
preserve mocha test context in both setup and assertion blocks

### DIFF
--- a/lib/ember-mocha/it.js
+++ b/lib/ember-mocha/it.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import { getContext } from 'ember-test-helpers';
 
 function resetViews() {
   Ember.View.views = {};
@@ -16,12 +15,12 @@ function wrap(specifier) {
     } else if (callback.length === 1) {
       wrapper = function(done) {
         resetViews();
-        return callback.call(getContext(), done);
+        return callback.call(this, done);
       };
     } else {
       wrapper = function() {
         resetViews();
-        return callback.call(getContext());
+        return callback.call(this);
       };
     }
     specifier(testName, wrapper);

--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -1,3 +1,6 @@
+import Ember from 'ember';
+import { getContext } from 'ember-test-helpers';
+
 export function createModule(Constructor, name, description, callbacks, tests) {
   var module;
 
@@ -18,6 +21,12 @@ export function createModule(Constructor, name, description, callbacks, tests) {
   describe(module.name, function() {
     beforeEach(function() {
       module.setup();
+      var context = getContext();
+      var keys = Ember.keys(context);
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        this[key] = context[key];
+      }
     });
 
     afterEach(function() {


### PR DESCRIPTION
Standard Mocha uses the same context for both its `beforeEach` blocks and its
`it` block. Among other things, this enables setting up things like
spies in setup, and then making assertions. E.g.

``` js
   beforeEach(function() {
     this.spy = sinon.spy();
     callACallback({callback: this.spy});
   })

   it('calls the callback', function() {
     expect(this.spy).to.have.been.called
   })
```

Instead of swapping out the context of the `it` block, just mixin the
context of the test module into the existing mocha context. That way,
you can have the best of both worlds.
