### PR TITLE
Add mocha to generated bower.json.

### DIFF
--- a/build-support/bower.json
+++ b/build-support/bower.json
@@ -7,6 +7,8 @@
   ],
   "license": "Apache Version 2.0",
   "ignore": [ ],
-  "dependencies": { },
+  "dependencies": {
+    "mocha": "~2.0.1"
+  },
   "devDependencies": { }
 }


### PR DESCRIPTION
Right now to use (non ember-cli), you need to:
- `bower install --save-dev ember-mocha`
- `bower install --save-dev mocha`

Seems like this library requires `mocha` so we should just add it to our generated `bower.json`.
