### PR TITLE
Update Mocha to 2.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "ember-test-helpers": "^0.0.6"
   },
   "devDependencies": {
-    "mocha": "~2.0.1",
+    "mocha": "~2.1.0",
     "chai": "~1.10.0",
     "ember-mocha-adapter": "~0.2.1",
     "loader": "stefanpenner/loader.js#1.0.1",


### PR DESCRIPTION
Hey, Mocha 2.1.0 features this [small fix](https://github.com/mochajs/mocha/commit/221e0360e23a41e4b8583a22a7a5f3a3aa5f55cb) that restores the ability to click the name of a test to run it individually, which obviates the minor-but-persistent hassle of re-adding “tests” to the beginning of the pathname when I need to focus on a test.

I was specifying 2.1.0 in `bower.json` and that worked okay locally, but Heroku and Travis builds were failing, so I figured I’d make this fork.

This update might not be useful for everyone, feel free to close if it seems unnecessary.
