### PR TITLE
Add broccoli-cli for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 install:
-  - npm install -g bower broccoli-cli
+  - npm install -g bower
   - npm install
   - bower install
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "bower": "^1.3.12",
     "broccoli": "^0.13.0",
+    "broccoli-cli": "0.0.1",
     "broccoli-concat": "^0.0.11",
     "broccoli-es6-concatenator": "^0.1.7",
     "broccoli-funnel": "^0.1.6",


### PR DESCRIPTION
When submitting #11, I had to install `broccoli-cli` to be able to run the tests. This formalises that development dependency.
