### PR TITLE
CI: Publish tags to NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,16 @@ script:
   - npm test
 
 deploy:
-  provider: script
-  script: .travis/deploy.sh
-  on:
-    tags: true
-    repo: emberjs/ember-mocha
+  - provider: npm
+    email: tobias.bieniek@gmx.de
+    api_key:
+      secure: gBwrB+pS88CLrmwidwapdLmcyqj6cgguica2vGlM88sOllVIu8gfPo3fQ9UB0uCHlrhfx41lq+lMTqeXbYen0U0ltc4YnnTWo92i5myeuAWZRYC+4fi+8afLLugwSd7afbTsrmQyXoZuEggXyjQYEr/xZ0KzdqIeL4YFxp4z6m8=
+    on:
+      tags: true
+      repo: emberjs/ember-mocha
+
+  - provider: script
+    script: .travis/deploy.sh
+    on:
+      tags: true
+      repo: emberjs/ember-mocha


### PR DESCRIPTION
This PR will instruct TravisCI to automatically publish to NPM when tags are pushed to this repo.

@wifelette suggested to use the https://www.npmjs.com/~ember account, but since I don't have access to that account yet I've used my own for now.

Resolves #99 

/cc @rwjblue @nathanhammond @stefanpenner 