### PR TITLE
package.json: Add "files" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "start": "ember serve",
     "test": "ember test"
   },
+  "files": [
+    "build-support",
+    "lib"
+  ],
   "dependencies": {
     "ember-test-helpers": "^0.5.33"
   },


### PR DESCRIPTION
This PR adds a `files` section to the `package.json` file to make sure we publish only the files that are really necessary.

/cc @rwjblue @stefanpenner 