### PR TITLE
mocha-module: Add upgrade guide URL to the deprecation message

### DIFF
--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -6,7 +6,7 @@ export function createModule(Constructor, name, description, callbacks, tests, m
     'The describeModule(), describeModel() and describeComponent() methods have been deprecated in favor of ' +
     'setupTest(), setupModelTest() and setupComponentTest().',
     false,
-    { id: 'ember-mocha.describe-helpers', until: '1.0.0' }
+    { id: 'ember-mocha.describe-helpers', until: '1.0.0', url: 'https://github.com/emberjs/ember-mocha#upgrading' }
   );
 
   var module;


### PR DESCRIPTION
![bildschirmfoto 2016-11-23 um 22 38 00](https://cloud.githubusercontent.com/assets/141300/20579550/8aab8f00-b1cd-11e6-8ac9-b63811b69e42.png)

This got unlocked by #106 

/cc @rwjblue 
