### PR TITLE
Remove "chai" vendor shim

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,8 +1,0 @@
-/* globals chai */
-
-export var expect = chai.expect;
-export var assert = chai.assert;
-
-export var config = chai.config;
-export var use = chai.use;
-export var Assertion = chai.Assertion;

--- a/tests/describe-component-test.js
+++ b/tests/describe-component-test.js
@@ -3,7 +3,8 @@ import { describeComponent, it } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 import { grepFor } from './test-support/mocha-support';
 import { describe } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 var PrettyColor = Ember.Component.extend({
   classNames: ['pretty-color'],

--- a/tests/describe-model-test.js
+++ b/tests/describe-model-test.js
@@ -4,7 +4,8 @@ import { describeModel, it } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 import { grepFor } from './test-support/mocha-support';
 import { describe } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 /* globals Pretender */
 

--- a/tests/describe-module-test.js
+++ b/tests/describe-module-test.js
@@ -3,7 +3,8 @@ import { describeModule, it } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 import { grepFor } from './test-support/mocha-support';
 import { describe } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 function setupRegistry() {
   setResolverRegistry({

--- a/tests/it-test.js
+++ b/tests/it-test.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import { it } from 'ember-mocha';
 import { grepFor } from './test-support/mocha-support';
 import { describe } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 function tryMochaSpecifier(fn) {
   try {

--- a/tests/mocha-module-test.js
+++ b/tests/mocha-module-test.js
@@ -1,7 +1,8 @@
 import { createModule } from 'ember-mocha/mocha-module';
 import { TestModule } from 'ember-test-helpers';
 import { describe, it, before, after, beforeEach, afterEach, mocha } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 describe('MochaModule', function() {
   createModule(TestModule, 'component:x-foo', 'context', function() {

--- a/tests/setup-component-test-test.js
+++ b/tests/setup-component-test-test.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import { setupComponentTest } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 import { describe, it, beforeEach } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 var PrettyColor = Ember.Component.extend({
   classNames: ['pretty-color'],

--- a/tests/setup-model-test-test.js
+++ b/tests/setup-model-test-test.js
@@ -3,7 +3,8 @@ import DS from 'ember-data';
 import { setupModelTest } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
 import { describe, it } from 'mocha';
-import { expect } from 'chai';
+
+const { expect } = window.chai;
 
 /* globals Pretender */
 

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -1,17 +1,16 @@
 import Ember from 'ember';
 import { mocha, describe, context, it, before, after, beforeEach, afterEach } from 'mocha';
-import { expect, assert, config, use, Assertion } from 'chai';
 
 describe('mocha-shim', function() {
   beforeEach(function() {
     this.beforeEachRunInEmberRunLoop = Ember.run.currentRunLoop;
   });
   afterEach(function() {
-    expect(Ember.run.currentRunLoop).to.be.ok;
+    window.chai.expect(Ember.run.currentRunLoop).to.be.ok;
   });
 
   it('runs the beforeEach hook inside the run loop', function() {
-    expect(this.beforeEachRunInEmberRunLoop).to.be.ok;
+    window.chai.expect(this.beforeEachRunInEmberRunLoop).to.be.ok;
   });
 
   it('should work', function() {
@@ -23,15 +22,5 @@ describe('mocha-shim', function() {
     window.chai.expect(after).to.equal(window.after);
     window.chai.expect(beforeEach.withoutEmberRun).to.equal(window.beforeEach);
     window.chai.expect(afterEach.withoutEmberRun).to.equal(window.afterEach);
-  });
-});
-
-describe('chai-shim', function() {
-  it('should work', function() {
-    window.chai.expect(expect).to.equal(window.chai.expect);
-    window.chai.expect(assert).to.equal(window.chai.assert);
-    window.chai.expect(config).to.equal(window.chai.config);
-    window.chai.expect(use).to.equal(window.chai.use);
-    window.chai.expect(Assertion).to.equal(window.chai.Assertion);
   });
 });


### PR DESCRIPTION
This will be provided by [ember-cli-chai](https://github.com/ember-cli/ember-cli-chai) now, and people using globals will probably use the "chai" global anyway.

Resolves part of https://github.com/ember-cli/ember-cli-mocha/issues/132