### PR TITLE
Update "ember-test-helpers" to v0.6.0-beta.1

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,7 +26,6 @@ module.exports = function(defaults) {
   });
 
   var emberTestHelpersPath = path.dirname(resolve.sync('ember-test-helpers'));
-  var klassyPath = path.dirname(resolve.sync('klassy', { basedir: emberTestHelpersPath }));
 
   var emberTestHelpers = new Funnel(emberTestHelpersPath, {
     srcDir: '/',
@@ -34,13 +33,7 @@ module.exports = function(defaults) {
     destDir: '/'
   });
 
-  // TODO - this manual dependency management has got to go!
-  var klassy = new Funnel(klassyPath, {
-    srcDir: '/',
-    files: ['klassy.js'],
-    destDir: '/'
-  });
-  var deps = mergeTrees([klassy, emberTestHelpers]);
+  var deps = mergeTrees([emberTestHelpers]);
 
   var lib = new Funnel('lib', {
     srcDir: '/',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "dependencies": {
-    "ember-test-helpers": "^0.5.33"
+    "ember-test-helpers": "^0.6.0-beta.1"
   },
   "devDependencies": {
     "broccoli-babel-transpiler": "^5.5.0",


### PR DESCRIPTION
... and remove "klassy" (see emberjs/ember-test-helpers#183)

This is unfortunately a breaking change (for ember-cli-mocha) and will require a major version bump (minor version bump actually since we're sub-1.0).

/cc @rwjblue @dgeb 