### PR TITLE
Fix and promote setupAcceptanceTest() and deprecate implicit async behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,35 @@ describe('Contact', function() {
 ```
 
 
+#### Acceptance Tests
+
+The `setupAcceptanceTest` function can be used to run acceptance
+tests as the name suggests. It will automatically setup an
+application instance for you, which is provided at `this.application`.
+
+```javascript
+import Ember from 'ember';
+import { describe, it } from 'mocha';
+import { setupAcceptanceTest } from 'ember-mocha';
+
+var Application = Ember.Application.extend({
+  rootElement: '#ember-testing',
+});
+
+describe('basic acceptance test', function() {
+  setupAcceptanceTest({ Application });
+
+  it('can visit /', function() {
+    visit('/');
+
+    andThen(() => {
+      expect(currentURL()).to.equal('/');
+    });
+  });
+});
+```
+
+
 Upgrading
 ------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -161,12 +161,20 @@ describe('basic acceptance test', function() {
   it('can visit /', function() {
     visit('/');
 
-    andThen(() => {
+    return andThen(() => {
       expect(currentURL()).to.equal('/');
     });
   });
 });
 ```
+
+Please make sure to always `return` your last async test helper from
+the test function. This will actually return a `Promise` which is letting
+the Mocha test framework know that this is an async test. Note that you can
+also add `return wait();` to the end of your acceptance tests.
+
+While this currently still works without the `return`, it will fail once
+this library is updated to Mocha 3.x!
 
 
 Upgrading

--- a/build-support/ember-mocha-adapter.js
+++ b/build-support/ember-mocha-adapter.js
@@ -73,6 +73,14 @@
       isPromise = true;
       result.then(function() { complete(); }, complete);
     } else {
+      Ember.deprecate('Relying on the implicit async behavior of acceptance tests is deprecated. ' +
+        'Please make sure to `return` your last async helper (e.g. `return andThen(...);`) from ' +
+        'the test function or add `return wait();` to the end of your acceptance tests.\n\nThis will ' +
+        'allow you to upgrade to Mocha 3.x soon.\n\n', isAsync === 0, {
+        id: 'ember-mocha.implicit-async',
+        url: 'https://github.com/emberjs/ember-mocha#acceptance-tests'
+      });
+
       if (isAsync === 0) { complete(); }
     }
   }

--- a/lib/ember-mocha/setup-test-factory.js
+++ b/lib/ember-mocha/setup-test-factory.js
@@ -1,9 +1,15 @@
+import Ember from 'ember';
 import { before, beforeEach, afterEach } from 'mocha';
 import { getContext } from 'ember-test-helpers';
 
 export default function(Constructor) {
-  return function setupTest(moduleName, options) {
+  return function setupTest(moduleName, options = {}) {
     var module;
+
+    if (Ember.typeOf(moduleName) === 'object') {
+      options = moduleName;
+      moduleName = '';
+    }
 
     before(function() {
       module = new Constructor(moduleName, options);

--- a/tests/acceptance-test.js
+++ b/tests/acceptance-test.js
@@ -39,7 +39,7 @@ describe('basic acceptance test', function() {
 
     visit('/foo');
 
-    andThen(function() {
+    return andThen(function() {
       expect(find('h2').text()).to.be.equal('this is an acceptance test');
     });
   });

--- a/tests/setup-acceptance-test-test.js
+++ b/tests/setup-acceptance-test-test.js
@@ -34,7 +34,7 @@ describe('setupAcceptanceTest()', function() {
 
     visit('/foo');
 
-    andThen(() => {
+    return andThen(() => {
       expect(find('h2').text()).to.be.equal('this is an acceptance test');
     });
   });

--- a/tests/setup-acceptance-test-test.js
+++ b/tests/setup-acceptance-test-test.js
@@ -1,0 +1,41 @@
+/* global visit, andThen */
+
+import Ember from 'ember';
+import { describe, it } from 'mocha';
+import { setupAcceptanceTest } from 'ember-mocha';
+
+const { expect } = window.chai;
+
+var Router = Ember.Router.extend();
+
+Router.map(function() {
+  this.route('foo');
+});
+
+var App = Ember.Application.extend({
+  rootElement: '#ember-testing',
+  Router: Router
+});
+
+App.FooController = Ember.Controller.extend({
+});
+
+describe('setupAcceptanceTest()', function() {
+  this.timeout(5000);
+
+  setupAcceptanceTest({ Application: App });
+
+  it('can visit subroutes', function() {
+    visit('/');
+
+    andThen(() => {
+      expect(find('h2').text()).to.be.empty;
+    });
+
+    visit('/foo');
+
+    andThen(() => {
+      expect(find('h2').text()).to.be.equal('this is an acceptance test');
+    });
+  });
+});


### PR DESCRIPTION
This essentially also deprecates the `ember-mocha-adapter` itself since its only purpose is supporting that implicit async behavior.

/cc @rwjblue @teddyzeenny