### PR TITLE
Ensure ember-test-helpers ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "dependencies": {
-    "ember-test-helpers": "^0.6.0-beta.1"
+    "ember-test-helpers": "^0.6.0"
   },
   "devDependencies": {
     "broccoli-babel-transpiler": "^5.5.0",


### PR DESCRIPTION
I was experiencing some weird problems and noticed that I was resolving to 0.6.0-beta.1 instead of 0.6.0. I think bumping this resolution to ^0.6.0 or better is appropriate so some don't accidentally resolve to the beta.