### PR TITLE
Pin "ember-test-helpers" to v0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "dependencies": {
-    "ember-test-helpers": "^0.6.0"
+    "ember-test-helpers": "0.6.2"
   },
   "devDependencies": {
     "broccoli-babel-transpiler": "^5.5.0",


### PR DESCRIPTION
the `v0.11.x` branch and `master` are currently failing:

```
not ok 1 PhantomJS 2.1 - Global error: Error: Could not find module require at http://localhost:7357/assets/loader.js, line 58
```

see https://github.com/emberjs/ember-test-helpers/issues/203