### PR TITLE
Update and pin "loader.js" to v4.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "mocha": "^2.5.3",
     "chai": "^3.5.0",
-    "loader": "stefanpenner/loader.js#1.0.1",
+    "loader.js": "4.1.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "pretender": "^0.6.0",
     "jquery": "~2.1.1",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,7 +20,7 @@ module.exports = function(defaults) {
   // --- Compile ES6 modules ---
 
   var loader = new Funnel('bower_components', {
-    srcDir: 'loader',
+    srcDir: 'loader.js/lib/loader',
     files: ['loader.js'],
     destDir: '/assets/'
   });


### PR DESCRIPTION
Pinned to v4.1.0 due to https://github.com/ember-cli/loader.js/pull/95#pullrequestreview-33045304

Closes #145 