### PR TITLE
Undeprecate the implicit async behavior of acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,20 +161,12 @@ describe('basic acceptance test', function() {
   it('can visit /', function() {
     visit('/');
 
-    return andThen(() => {
+    andThen(() => {
       expect(currentURL()).to.equal('/');
     });
   });
 });
 ```
-
-Please make sure to always `return` your last async test helper from
-the test function. This will actually return a `Promise` which is letting
-the Mocha test framework know that this is an async test. Note that you can
-also add `return wait();` to the end of your acceptance tests.
-
-While this currently still works without the `return`, it will fail once
-this library is updated to Mocha 3.x!
 
 #### Using `async/await`
 

--- a/build-support/ember-mocha-adapter.js
+++ b/build-support/ember-mocha-adapter.js
@@ -73,14 +73,6 @@
       isPromise = true;
       result.then(function() { complete(); }, complete);
     } else {
-      Ember.deprecate('Relying on the implicit async behavior of acceptance tests is deprecated. ' +
-        'Please make sure to `return` your last async helper (e.g. `return andThen(...);`) from ' +
-        'the test function or add `return wait();` to the end of your acceptance tests.\n\nThis will ' +
-        'allow you to upgrade to Mocha 3.x soon.\n\n', isAsync === 0, {
-        id: 'ember-mocha.implicit-async',
-        url: 'https://github.com/emberjs/ember-mocha#acceptance-tests'
-      });
-
       if (isAsync === 0) { complete(); }
     }
   }

--- a/build-support/ember-mocha-adapter.js
+++ b/build-support/ember-mocha-adapter.js
@@ -78,7 +78,6 @@
         'the test function or add `return wait();` to the end of your acceptance tests.\n\nThis will ' +
         'allow you to upgrade to Mocha 3.x soon.\n\n', isAsync === 0, {
         id: 'ember-mocha.implicit-async',
-        until: '1.0.0',
         url: 'https://github.com/emberjs/ember-mocha#acceptance-tests'
       });
 

--- a/build-support/ember-mocha-adapter.js
+++ b/build-support/ember-mocha-adapter.js
@@ -73,13 +73,10 @@
       isPromise = true;
       result.then(function() { complete(); }, complete);
     } else {
-      var testName = getTestName(context);
-      var messageSuffix = testName ? ('Test: ' + testName + '\n\n') : '';
-
       Ember.deprecate('Relying on the implicit async behavior of acceptance tests is deprecated. ' +
         'Please make sure to `return` your last async helper (e.g. `return andThen(...);`) from ' +
         'the test function or add `return wait();` to the end of your acceptance tests.\n\nThis will ' +
-        'allow you to upgrade to Mocha 3.x soon.\n\n'+ messageSuffix, isAsync === 0, {
+        'allow you to upgrade to Mocha 3.x soon.\n\n', isAsync === 0, {
         id: 'ember-mocha.implicit-async',
         until: '1.0.0',
         url: 'https://github.com/emberjs/ember-mocha#acceptance-tests'
@@ -87,21 +84,6 @@
 
       if (isAsync === 0) { complete(); }
     }
-  }
-
-  function getTestName(context) {
-    var titles = [];
-
-    var node = context.test;
-    while (node) {
-      if (node.title) {
-        titles.push(node.title);
-      }
-
-      node = node.parent;
-    }
-
-    return titles.reverse().join(' ');
   }
 
   // Called whenever an async test passes or fails.

--- a/tests/acceptance-test.js
+++ b/tests/acceptance-test.js
@@ -39,7 +39,7 @@ describe('basic acceptance test', function() {
 
     visit('/foo');
 
-    return andThen(function() {
+    andThen(function() {
       expect(find('h2').text()).to.be.equal('this is an acceptance test');
     });
   });

--- a/tests/setup-acceptance-test-test.js
+++ b/tests/setup-acceptance-test-test.js
@@ -34,7 +34,7 @@ describe('setupAcceptanceTest()', function() {
 
     visit('/foo');
 
-    return andThen(() => {
+    andThen(() => {
       expect(find('h2').text()).to.be.equal('this is an acceptance test');
     });
   });


### PR DESCRIPTION
we will need to find a better way without breaking the world...