### PR TITLE
Fix memory leak in context cleanup

### DIFF
--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -38,6 +38,9 @@ export function createModule(Constructor, name, description, callbacks, tests, m
     });
 
     afterEach(function() {
+      Object.keys(this).forEach(key => {
+        this[key] = null;
+      });
       return module.teardown();
     });
 

--- a/lib/ember-mocha/setup-test-factory.js
+++ b/lib/ember-mocha/setup-test-factory.js
@@ -25,10 +25,16 @@ export default function(Constructor) {
     });
 
     afterEach(function() {
+      Object.keys(this).forEach(key => {
+        this[key] = null;
+      });
       return module.teardown();
     });
 
     after(function() {
+      Object.keys(this).forEach(key => {
+        this[key] = null;
+      });
       module = null;
     });
   };


### PR DESCRIPTION
Addresses https://github.com/emberjs/ember-mocha/issues/167

Note in screen shot, no containers are left behind:

<img width="1501" alt="screen shot 2017-11-08 at 9 59 06 am" src="https://user-images.githubusercontent.com/123911/32565302-82e94ce2-c46b-11e7-81e4-e34b92f79aa2.png">