### PR TITLE
[WIP] Add support for new RFC268 based testing API

### DIFF
--- a/addon-test-support/ember-mocha/index.js
+++ b/addon-test-support/ember-mocha/index.js
@@ -1,9 +1,12 @@
-import describeModule    from 'ember-mocha/describe-module';
-import describeComponent from 'ember-mocha/describe-component';
-import describeModel     from 'ember-mocha/describe-model';
-import setupTestFactory  from 'ember-mocha/setup-test-factory';
-import { it }            from 'mocha';
-import { setResolver }   from '@ember/test-helpers';
+import describeModule       from 'ember-mocha/describe-module';
+import describeComponent    from 'ember-mocha/describe-component';
+import describeModel        from 'ember-mocha/describe-model';
+import setupTestFactory     from 'ember-mocha/setup-test-factory';
+import setupContainerTest   from 'ember-mocha/setup-container-test';
+import setupRenderingTest   from 'ember-mocha/setup-rendering-test';
+import setupApplicationTest from 'ember-mocha/setup-application-test';
+import { it }               from 'mocha';
+import { setResolver }      from '@ember/test-helpers';
 import {
   TestModule,
   TestModuleForModel,
@@ -24,6 +27,9 @@ export {
   setupAcceptanceTest,
   setupComponentTest,
   setupModelTest,
+  setupContainerTest,
+  setupRenderingTest,
+  setupApplicationTest,
   it,
   setResolver
 };

--- a/addon-test-support/ember-mocha/setup-application-test.js
+++ b/addon-test-support/ember-mocha/setup-application-test.js
@@ -1,0 +1,21 @@
+import {
+  beforeEach,
+  afterEach
+} from 'mocha';
+import {
+  setupApplicationContext,
+  teardownApplicationContext
+} from '@ember/test-helpers';
+import setupContainerTest from './setup-container-test';
+
+export default function setupApplicationTest(options) {
+  afterEach(function() {
+    return teardownApplicationContext(this);
+  });
+
+  setupContainerTest(options);
+
+  beforeEach(function() {
+    return setupApplicationContext(this);
+  });
+}

--- a/addon-test-support/ember-mocha/setup-container-test.js
+++ b/addon-test-support/ember-mocha/setup-container-test.js
@@ -1,0 +1,43 @@
+import {
+  beforeEach,
+  afterEach
+} from 'mocha';
+import {
+  setupContext,
+  teardownContext
+} from '@ember/test-helpers';
+import { assign, merge } from '@ember/polyfills';
+
+const _assign = assign || merge;
+
+export default function setupUnitTest(options) {
+  let originalContext;
+
+  beforeEach(function() {
+    originalContext = _assign({}, this);
+
+    return setupContext(this, options).then(() => {
+
+      let originalPauseTest = this.pauseTest;
+      this.pauseTest = function Mocha_pauseTest() {
+        this.timeout(0); // prevent the test from timing out
+
+        return originalPauseTest.call(this);
+      };
+    });
+  });
+
+  afterEach(function() {
+    return teardownContext(this).then(() => {
+      // delete any extraneous properties
+      for (let key in this) {
+        if (!(key in originalContext)) {
+          delete this[key];
+        }
+      }
+
+      // copy over the original values
+      _assign(this, originalContext);
+    });
+  });
+}

--- a/addon-test-support/ember-mocha/setup-rendering-test.js
+++ b/addon-test-support/ember-mocha/setup-rendering-test.js
@@ -1,0 +1,21 @@
+import {
+  beforeEach,
+  afterEach
+} from 'mocha';
+import {
+  setupRenderingContext,
+  teardownRenderingContext
+} from '@ember/test-helpers';
+import setupContainerTest from './setup-container-test';
+
+export default function setupRenderingTest(options) {
+  afterEach(function() {
+    return teardownRenderingContext(this);
+  });
+
+  setupContainerTest(options);
+
+  beforeEach(function() {
+    return setupRenderingContext(this);
+  });
+}

--- a/tests/acceptance/setup-application-test-test.js
+++ b/tests/acceptance/setup-application-test-test.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'mocha';
+import { setupApplicationTest } from 'ember-mocha';
+import { expect } from 'chai';
+import { setApplication, visit } from '@ember/test-helpers';
+import Application from '../../app';
+import config from '../../config/environment';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+describe('setupApplicationTest', function() {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
+  setApplication(Application.create(Object.assign({}, config.APP, { autoboot: false })));
+
+  this.timeout(5000);
+
+  setupApplicationTest();
+
+  it('can visit subroutes', async function() {
+    await visit('/');
+    expect(this.element.querySelector('h2').textContent.trim()).to.be.empty;
+
+    await visit('/foo');
+    expect(this.element.querySelector('h2').textContent.trim()).to.be.equal('this is an acceptance test');
+  });
+});

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 module.exports = {
   browsers: [
-    'ie 9',
     'last 1 Chrome versions',
     'last 1 Firefox versions',
     'last 1 Safari versions'

--- a/tests/unit/setup-container-test-test.js
+++ b/tests/unit/setup-container-test-test.js
@@ -1,0 +1,81 @@
+import { setupContainerTest } from 'ember-mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import { pauseTest, resumeTest } from '@ember/test-helpers';
+import Service from '@ember/service';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+describe('setupContainerTest', function() {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
+  describe('context setup', function() {
+
+    setupContainerTest();
+
+    afterEach(function() {
+      expect(this.owner, 'Context does not leak between tests').to.be.undefined;
+    });
+
+    it('sets up owner', function() {
+      expect(this.owner, 'Owner exists').to.exist;
+      this.owner.register('service:dummy', Service.extend({ foo: 'bar' }));
+
+      let subject = this.owner.lookup('service:dummy');
+      expect(subject.get('foo')).to.equal('bar');
+    });
+
+    it('has setters and getters', function() {
+      expect(this)
+        .to.respondTo('get')
+        .and.to.respondTo('getProperties')
+        .and.to.respondTo('set')
+        .and.to.respondTo('setProperties');
+
+      this.set('foo', 'bar');
+      expect(this.get('foo')).to.equal('bar');
+    });
+  });
+
+  describe('pauseTest/resumeTest', function() {
+
+    setupContainerTest();
+
+    it('can pause tests without timeouts', async function() {
+      this.timeout(100);
+
+      setTimeout(resumeTest, 200); // resume test after timeout
+      // make sure pauseTest does not wait forever, if resumeTest fails
+      let timer = setTimeout(() => {
+        throw new Error('resumeTest() did not work')
+      }, 300);
+
+      await pauseTest();
+      clearTimeout(timer);
+    });
+  });
+
+  describe('context in beforeEach/afterEach hooks', function() {
+
+    // @todo will throw `this.get is not a function` if called after `setupRenderingTest()`
+    afterEach(function() {
+      expect(this.get('name')).to.equal('blue');
+    });
+
+    setupContainerTest();
+
+    beforeEach(function() {
+      this.set('name', 'red');
+    });
+
+    beforeEach(function() {
+      expect(this.get('name')).to.equal('red');
+    });
+
+    it('has correct context', async function() {
+      expect(this.get('name')).to.equal('red');
+      this.set('name', 'blue');
+    });
+  });
+});

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -1,0 +1,48 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { setupRenderingTest } from 'ember-mocha';
+import { describe, it, beforeEach } from 'mocha';
+import { expect } from 'chai';
+import hbs from 'htmlbars-inline-precompile';
+import { render } from '@ember/test-helpers';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+const PrettyColor = Component.extend({
+  classNames: ['pretty-color'],
+  attributeBindings: ['style'],
+  style: computed('name', function() {
+    return 'color: ' + this.get('name') + ';';
+  })
+});
+
+function setupRegistry(owner) {
+  owner.register('component:x-foo', Component.extend());
+  owner.register('component:pretty-color', PrettyColor);
+  owner.register('template:components/pretty-color', hbs`Pretty Color: <span class="color-name">{{name}}</span>`);
+}
+
+describe('setupRenderingTest', function() {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
+  describe('pretty-color', function() {
+    setupRenderingTest();
+
+    beforeEach(function() {
+      setupRegistry(this.owner);
+    });
+
+    it('renders with color', async function() {
+      this.set('name', 'green');
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: green');
+    });
+
+    it('renders a second time without', async function() {
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color:');
+    });
+  });
+
+});


### PR DESCRIPTION
@rwjblue @Turbo87 here's a first attempt at implementing the new testing APIs for Mocha, as we discussed recently on Slack.

@rwjblue your [gist](https://gist.github.com/rwjblue/bbfa75170ea7287a3dc71c9c647f4f4e) was working almost perfectly! 👍 
I added few tests, for application and rendering more or less based on the existing ones. For `setupUnitTest` some more specific cases. Tell me if you feel there is something missing!

Nevertheless there are some problems:
* `setupTest()`, as it is called in `ember-qunit`, is already taken by `ember-mocha` for the old APIs. I named the function for now `setupUnitTest`. Would have been nice to having matching names, but seems we cannot do this in this case.
* The apparent FIFO ordering of before/after hooks causes after hooks to be called with a cleared up context when called after `setup*Test()`, see [here](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:new-test-api?expand=1#diff-3abb3578fa023be5a34ac25e7ba855b3R55). I think that's what you were chatting about at the end of the recent conversation, right? 🤔

