### PR TITLE
Add hooks API for setupContainerTest() to improve beforeEach/afterEach ordering

### DIFF
--- a/addon-test-support/ember-mocha/setup-application-test.js
+++ b/addon-test-support/ember-mocha/setup-application-test.js
@@ -1,21 +1,18 @@
 import {
-  beforeEach,
-  afterEach
-} from 'mocha';
-import {
   setupApplicationContext,
   teardownApplicationContext
 } from '@ember/test-helpers';
 import setupContainerTest from './setup-container-test';
 
 export default function setupApplicationTest(options) {
-  afterEach(function() {
+  let hooks = setupContainerTest(options);
+
+  hooks.beforeEach(function() {
+    return setupApplicationContext(this);
+  });
+  hooks.afterEach(function() {
     return teardownApplicationContext(this);
   });
 
-  setupContainerTest(options);
-
-  beforeEach(function() {
-    return setupApplicationContext(this);
-  });
+  return hooks;
 }

--- a/addon-test-support/ember-mocha/setup-container-test.js
+++ b/addon-test-support/ember-mocha/setup-container-test.js
@@ -7,16 +7,23 @@ import {
   teardownContext
 } from '@ember/test-helpers';
 import { assign, merge } from '@ember/polyfills';
+import { resolve } from 'rsvp';
 
 const _assign = assign || merge;
 
+function chainHooks(hooks, context, promise = resolve()) {
+  return hooks.reduce((promise, fn) => promise.then(fn.bind(context)), promise);
+}
+
 export default function setupUnitTest(options) {
   let originalContext;
+  let beforeEachHooks = [];
+  let afterEachHooks = [];
 
   beforeEach(function() {
     originalContext = _assign({}, this);
 
-    return setupContext(this, options).then(() => {
+    let promise = setupContext(this, options).then(() => {
 
       let originalPauseTest = this.pauseTest;
       this.pauseTest = function Mocha_pauseTest() {
@@ -25,19 +32,50 @@ export default function setupUnitTest(options) {
         return originalPauseTest.call(this);
       };
     });
+
+    return chainHooks(beforeEachHooks, this, promise);
   });
 
   afterEach(function() {
-    return teardownContext(this).then(() => {
-      // delete any extraneous properties
-      for (let key in this) {
-        if (!(key in originalContext)) {
-          delete this[key];
-        }
-      }
+    let promise = chainHooks(afterEachHooks, this);
 
-      // copy over the original values
-      _assign(this, originalContext);
-    });
+    return promise
+      .then(() => teardownContext(this))
+      .then(() => {
+        // delete any extraneous properties
+        for (let key in this) {
+          if (!(key in originalContext)) {
+            delete this[key];
+          }
+        }
+
+        // copy over the original values
+        _assign(this, originalContext);
+      });
   });
+
+  /**
+   * Provide a workaround for the inconvenient FIFO-always order of beforeEach/afterEach calls
+   *
+   * ```js
+   * let hooks = setupTest();
+   * hooks.beforeEach(function() { ... });
+   * hooks.afterEach(function() { ... });
+   * ```
+   *
+   * beforeEach hooks are called after setupUnitTest#beforeEach in FIFO (first in first out) order
+   * afterEach hooks are called before setupUnitTest#afterEach in LIFO (last in first out) order
+   *
+   * @type {{beforeEach: (function(*)), afterEach: (function(*))}}
+   */
+  let hooks = {
+    beforeEach(fn) {
+      beforeEachHooks.push(fn);
+    },
+    afterEach(fn) {
+      afterEachHooks.unshift(fn);
+    }
+  };
+
+  return hooks;
 }

--- a/addon-test-support/ember-mocha/setup-rendering-test.js
+++ b/addon-test-support/ember-mocha/setup-rendering-test.js
@@ -1,21 +1,18 @@
 import {
-  beforeEach,
-  afterEach
-} from 'mocha';
-import {
   setupRenderingContext,
   teardownRenderingContext
 } from '@ember/test-helpers';
 import setupContainerTest from './setup-container-test';
 
 export default function setupRenderingTest(options) {
-  afterEach(function() {
+  let hooks = setupContainerTest(options);
+
+  hooks.beforeEach(function() {
+    return setupRenderingContext(this);
+  });
+  hooks.afterEach(function() {
     return teardownRenderingContext(this);
   });
 
-  setupContainerTest(options);
-
-  beforeEach(function() {
-    return setupRenderingContext(this);
-  });
+  return hooks;
 }

--- a/tests/acceptance/setup-application-test-test.js
+++ b/tests/acceptance/setup-application-test-test.js
@@ -15,13 +15,27 @@ describe('setupApplicationTest', function() {
 
   this.timeout(5000);
 
-  setupApplicationTest();
+  describe('acceptance test', function() {
 
-  it('can visit subroutes', async function() {
-    await visit('/');
-    expect(this.element.querySelector('h2').textContent.trim()).to.be.empty;
+    setupApplicationTest();
 
-    await visit('/foo');
-    expect(this.element.querySelector('h2').textContent.trim()).to.be.equal('this is an acceptance test');
+    it('can visit subroutes', async function() {
+      await visit('/');
+      expect(this.element.querySelector('h2').textContent.trim()).to.be.empty;
+
+      await visit('/foo');
+      expect(this.element.querySelector('h2').textContent.trim()).to.be.equal('this is an acceptance test');
+    });
+  });
+
+  describe('hooks API', function() {
+
+    let hooks = setupApplicationTest();
+
+    it('returns hooks API', function() {
+      expect(hooks)
+        .to.respondTo('beforeEach')
+        .and.to.respondTo('afterEach');
+    })
   });
 });

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -45,4 +45,14 @@ describe('setupRenderingTest', function() {
     });
   });
 
+  describe('hooks API', function() {
+
+    let hooks = setupRenderingTest();
+
+    it('returns hooks API', function() {
+      expect(hooks)
+        .to.respondTo('beforeEach')
+        .and.to.respondTo('afterEach');
+    });
+  });
 });


### PR DESCRIPTION
As discussed in https://github.com/emberjs/ember-mocha/pull/190#discussion_r169258762