### PR TITLE
Remove mochaRunner global assignment to prevent memory leaks

### DIFF
--- a/vendor/ember-mocha/test-loader.js
+++ b/vendor/ember-mocha/test-loader.js
@@ -35,7 +35,7 @@
     setTimeout(function() {
       TestLoader.load();
 
-      window.mochaRunner = mocha.run();
+      mocha.run();
     }, 250);
   });
 })();


### PR DESCRIPTION
Just double checked with a large test suite, this change did not have any noticable effect (other than fixing the leak 😉).

Might also fix #168, not sure though. 

Related: https://github.com/emberjs/ember-mocha/pull/191#discussion_r169250060