### PR TITLE
Allow to customize the used mocha hooks in setup*Test

### DIFF
--- a/addon-test-support/ember-mocha/setup-container-test.js
+++ b/addon-test-support/ember-mocha/setup-container-test.js
@@ -24,12 +24,14 @@ function setupPauseTest(context) {
   };
 }
 
-export default function setupUnitTest(options) {
+export default function setupUnitTest(options = {}) {
   let originalContext;
   let beforeEachHooks = [];
   let afterEachHooks = [];
+  let beforeHook = options.beforeHook || beforeEach;
+  let afterHook = options.afterHook || afterEach;
 
-  beforeEach(function() {
+  beforeHook(function() {
     originalContext = _assign({}, this);
 
     return setupContext(this, options)
@@ -37,7 +39,7 @@ export default function setupUnitTest(options) {
       .then(() => chainHooks(beforeEachHooks, this));
   });
 
-  afterEach(function() {
+  afterHook(function() {
     return chainHooks(afterEachHooks, this)
       .then(() => teardownContext(this))
       .then(() => {

--- a/tests/unit/setup-container-test-test.js
+++ b/tests/unit/setup-container-test-test.js
@@ -158,6 +158,33 @@ describe('setupContainerTest', function() {
       });
     });
 
+    describe('hook customization', function() {
+      let beforeHookCalled = false;
+      let afterHookCalled = false;
+
+      function customBeforeHook(fn) {
+        expect(fn).to.be.a.function;
+        beforeHookCalled = true;
+      }
+      function customAfterHook(fn) {
+        expect(fn).to.be.a.function;
+        afterHookCalled = true;
+      }
+
+      setupContainerTest({
+        beforeHook: customBeforeHook,
+        afterHook: customAfterHook,
+      });
+
+      it('allow to use custom hooks', function() {
+        expect(beforeHookCalled).to.be.true;
+      });
+
+      after(function() {
+        expect(afterHookCalled).to.be.true;
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This allows to use hooks other than `beforeEach`/ `afterEach` to setup tests (new API), by passing them as options.

I know the use case I have for this is probably a bit weird, but so it is: 
In `ember-cli-yadda`, which we have used for some projects, there is a mode to run BDD feature tests in a way (to improve readability and traceability), that the test is actually a `describe` block, and the individual test steps map to `it` calls. See https://github.com/albertjan/ember-cli-yadda/releases/tag/0.2.0

This requires the setup and teardown works to be done in `before`/`after` vs. `beforeEach`/ `afterEach`. The change here enables you to do that.

Hope it's ok to land that, as it requires no big changes, even if it's a bit unusual...