### PR TITLE
Add failing async test

### DIFF
--- a/tests/unit/setup-test-test.js
+++ b/tests/unit/setup-test-test.js
@@ -4,7 +4,8 @@ import { expect } from 'chai';
 import { pauseTest, resumeTest } from '@ember/test-helpers';
 import Service from '@ember/service';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
-import { Promise } from 'rsvp';
+import { reject, Promise } from 'rsvp';
+import { run } from '@ember/runloop';
 
 describe('setupTest', function() {
   if (!hasEmberVersion(2, 4)) {
@@ -36,6 +37,23 @@ describe('setupTest', function() {
 
       this.set('foo', 'bar');
       expect(this.get('foo')).to.equal('bar');
+    });
+
+    describe('async', function() {
+      let endReached = false;
+
+      after(function() {
+        expect(endReached, 'Test aborted prematurely').to.be.true;
+      });
+
+      it('works with rejected promise', async function() {
+        this.timeout(0);
+        reject(); // eslint-disable-line no-unused-vars
+        run(() => {});
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        endReached = true;
+      });
     });
   });
 

--- a/vendor/ember-mocha/ember-mocha-adapter.js
+++ b/vendor/ember-mocha/ember-mocha-adapter.js
@@ -65,14 +65,16 @@
 
   function invoke(context, fn, d) {
     done = d;
-    isPromise = false;
+    isPromise = true;
     var result = fn.call(context);
     // If a promise is returned,
     // complete test when promise fulfills / rejects
     if (result && typeof result.then === 'function') {
-      isPromise = true;
-      result.then(function() { complete(); }, complete);
+      result.then(function() {
+        complete();
+        }, complete);
     } else {
+      isPromise = false;
       if (isAsync === 0) { complete(); }
     }
   }


### PR DESCRIPTION
This adds a failing test for a bug that I tried to hunt down for quite some time. The problem is that the test is finished before the promise (returned from the async `it` callback) has actually resolved. I.e. when the [last line](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:async-bug?expand=1#diff-00b254482eb1c40de2c78f0b6e0c9273R55) is reached, Mocha already has finished the test, as you can see here (test passed without assertions, but `after` failed as `endReached` has not been set to true yet):

![image](https://user-images.githubusercontent.com/1325249/36729803-ad1b29d4-1bc5-11e8-97e6-e5536f633344.png)

Some insights:

1. all four of the following conditions have to be met to make the test fail:
* `setupContainerTest()` is called
* the test is in a nested `describe()` ([L42](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:async-bug?expand=1#diff-00b254482eb1c40de2c78f0b6e0c9273R42))
* the (unused!) promise is created ([L51](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:async-bug?expand=1#diff-00b254482eb1c40de2c78f0b6e0c9273R51))
* the (unused!) run loop is created ([L52](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:async-bug?expand=1#diff-00b254482eb1c40de2c78f0b6e0c9273R52))
As soon as anyone of the conditions is not met, the test passes as it should.

I debugged the call to `complete` in the `Ember.Test.MochaAdapter`:
* it indeed is called by `asyncEnd`, and *not*  the resolved promise [here](https://github.com/emberjs/ember-mocha/blob/7833e14349f5136802d7a6bbe89bca34f97329e7/vendor/ember-mocha/ember-mocha-adapter.js#L74)
* the first call to `asyncStart` (increasing `isAsync` to 1) is caused by the Promise creation ([L51](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:async-bug?expand=1#diff-00b254482eb1c40de2c78f0b6e0c9273R51))
* the following call (to either `asyncStart` or `asyncEnd`) goes to `asyncEnd`, and is caused by the run loop creation in [L52](https://github.com/emberjs/ember-mocha/compare/master...simonihmig:async-bug?expand=1#diff-00b254482eb1c40de2c78f0b6e0c9273R52). This decreases `isAsync` to 0 and prematurely ends the test.
* interesting here: when these `async*` callbacks are called, `isPromise` is false!
