### PR TITLE
Fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-data": "^2.17.0",
+    "ember-data": "~2.17.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,7 +2106,7 @@ ember-cli@~2.17.0:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
-ember-data@^2.17.0:
+ember-data@~2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.17.0.tgz#d952cf98d7461abf41ed6d248cf2a5836c623276"
   dependencies:


### PR DESCRIPTION
The `ember-data@^2.17.0` requirement allowed `ember-data@2.18` to be a valid resolution, but that requires Node 6+ now, which is incompatible with our CI builds that still use Node 4 for now. This PR pins `ember-data` to v2.17.x for now to work around that issue until we update CI to use Node 6 too.