### PR TITLE
Add resetOnerror from @ember/test-helpers

### DIFF
--- a/addon-test-support/ember-mocha/index.js
+++ b/addon-test-support/ember-mocha/index.js
@@ -3,20 +3,20 @@
 export { loadTests } from './test-loader';
 
 import { loadTests } from './test-loader';
-import describeModule       from 'ember-mocha/describe-module';
-import describeComponent    from 'ember-mocha/describe-component';
-import describeModel        from 'ember-mocha/describe-model';
-import setupTestFactory     from 'ember-mocha/setup-test-factory';
-import setupTestNew         from 'ember-mocha/setup-test';
-import setupRenderingTest   from 'ember-mocha/setup-rendering-test';
+import describeModule from 'ember-mocha/describe-module';
+import describeComponent from 'ember-mocha/describe-component';
+import describeModel from 'ember-mocha/describe-model';
+import setupTestFactory from 'ember-mocha/setup-test-factory';
+import setupTestNew from 'ember-mocha/setup-test';
+import setupRenderingTest from 'ember-mocha/setup-rendering-test';
 import setupApplicationTest from 'ember-mocha/setup-application-test';
-import { it }               from 'mocha';
-import { setResolver }      from '@ember/test-helpers';
+import { it, afterEach } from 'mocha';
+import { setResolver, resetOnerror } from '@ember/test-helpers';
 import {
   TestModule,
   TestModuleForModel,
   TestModuleForComponent,
-  TestModuleForAcceptance
+  TestModuleForAcceptance,
 } from 'ember-test-helpers';
 
 const setupTestLegacy = setupTestFactory(TestModule);
@@ -40,6 +40,9 @@ export function startTests() {
   mocha.run();
 }
 
+function setupResetOnerror() {
+  afterEach(resetOnerror);
+}
 
 /**
  * @method start
@@ -49,6 +52,8 @@ export function startTests() {
  * (you must run `startTests()` to kick them off).
  */
 export function start(options = {}) {
+  setupResetOnerror();
+
   if (options.loadTests !== false) {
     loadTests();
   }
@@ -70,5 +75,5 @@ export {
   setupRenderingTest,
   setupApplicationTest,
   it,
-  setResolver
+  setResolver,
 };

--- a/addon-test-support/ember-mocha/index.js
+++ b/addon-test-support/ember-mocha/index.js
@@ -41,7 +41,9 @@ export function startTests() {
 }
 
 function setupResetOnerror() {
-  afterEach(resetOnerror);
+  afterEach(function() {
+    resetOnerror();
+  });
 }
 
 /**


### PR DESCRIPTION
This PR is paired with the new @ember/test-helpers API (setupOnerror/resetOnerror) for providing an Ember.onerror implementation (https://github.com/emberjs/ember-test-helpers/pull/548). This adds automatic wiring up of resetOnerror with mocha's root module `afterEach`, so we ensure that the Ember.onerror function is reset after each test.