### PR TITLE
Explicitly reexport `window.` properties

### DIFF
--- a/addon-test-support/mocha/index.js
+++ b/addon-test-support/mocha/index.js
@@ -1,8 +1,5 @@
 import Ember from 'ember';
 
-/*global mocha, describe, context, it, before, after */
-
-
 /**
  * Takes a function that defines a mocha hook, like `beforeEach` and
  * runs its callback inside an `Ember.run`.
@@ -64,9 +61,13 @@ function wrapMochaHookInEmberRun(original) {
   return wrapper;
 }
 
-
-
+var mocha = window.mocha;
+var describe = window.describe;
+var context = window.context;
+var it = window.it;
+var before = window.before;
 var beforeEach = wrapMochaHookInEmberRun(window.beforeEach);
+var after = window.after;
 var afterEach = wrapMochaHookInEmberRun(window.afterEach);
 
 export {


### PR DESCRIPTION
the `/*global*/` declaration seems to cause a parsing error with the latest set of dependencies...

/cc @scalvert