### PR TITLE
Drop support for Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "changelog": {
     "repo": "emberjs/ember-mocha",


### PR DESCRIPTION
probably should've done this before the v0.15.0 release... 🤷‍♂ 