### PR TITLE
Deprecate `setupTest()`, `setupComponentTest()`, `setupModelTest()` and `setupAcceptanceTest()` functions

### DIFF
--- a/addon-test-support/ember-mocha/index.js
+++ b/addon-test-support/ember-mocha/index.js
@@ -19,10 +19,10 @@ import {
   TestModuleForAcceptance,
 } from 'ember-test-helpers';
 
-const setupTestLegacy = setupTestFactory(TestModule);
-const setupAcceptanceTest = setupTestFactory(TestModuleForAcceptance);
-const setupComponentTest = setupTestFactory(TestModuleForComponent);
-const setupModelTest = setupTestFactory(TestModuleForModel);
+const setupTestLegacy = setupTestFactory(TestModule, 'setupTest');
+const setupAcceptanceTest = setupTestFactory(TestModuleForAcceptance, 'setupAcceptanceTest');
+const setupComponentTest = setupTestFactory(TestModuleForComponent, 'setupComponentTest');
+const setupModelTest = setupTestFactory(TestModuleForModel, 'setupModelTest');
 
 // wrapper function that supports the old and the new testing APIs, depending on its arguments
 function setupTest(moduleName) {

--- a/addon-test-support/ember-mocha/setup-test-factory.js
+++ b/addon-test-support/ember-mocha/setup-test-factory.js
@@ -2,8 +2,24 @@ import Ember from 'ember';
 import { before, beforeEach, afterEach, after } from 'mocha';
 import { getContext } from '@ember/test-helpers';
 
-export default function(Constructor) {
+export default function(Constructor, functionName) {
   return function setupTest(moduleName, options = {}) {
+    let deprecationMessage;
+    if (functionName === 'setupTest') {
+      deprecationMessage = 'The `setupTest()` function that accepts a module ' +
+        'name has been deprecated. Please use `setupTest()` without a module ' +
+        'name and look it up via `this.owner.lookup(moduleName)` instead.';
+    } else if (functionName === 'setupComponentTest') {
+      deprecationMessage = 'The `setupComponentTest()` function is deprecated. ' +
+        'Please use the `setupRenderingTest()` function instead.';
+    }  else if (functionName === 'setupAcceptanceTest') {
+      deprecationMessage = 'The `setupAcceptanceTest()` function is deprecated. ' +
+        'Please use the `setupApplicationTest()` function instead.';
+    } else {
+      deprecationMessage = `The \`${functionName}()\` function is deprecated. ` +
+        `Please use the \`setupTest()\` function instead.`;
+    }
+
     var module;
 
     if (Ember.typeOf(moduleName) === 'object') {
@@ -16,6 +32,12 @@ export default function(Constructor) {
     });
 
     beforeEach(function() {
+      Ember.deprecate(deprecationMessage, false, {
+        id: 'ember-mocha.setup-test',
+        until: '0.16.0',
+        url: 'https://github.com/emberjs/ember-mocha#upgrading',
+      });
+
       return module.setup().then(() => {
         var context = getContext();
         Object.keys(context).forEach(key => {


### PR DESCRIPTION
The "new" APIs have been around for a while now and it's time to get rid of the old APIs