### PR TITLE
Drop support for Ember.js v3.3 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,8 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-2.0
-    - EMBER_TRY_SCENARIO=ember-lts-2.4
-    - EMBER_TRY_SCENARIO=ember-lts-2.8
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-3.4
+    - EMBER_TRY_SCENARIO=ember-lts-3.8
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ helpers contained in
 [Migration Guide](docs/migration.md).*
 
 
+Compatibility
+------------------------------------------------------------------------------
+
+- Ember.js v3.4 or above
+- Ember CLI v2.13 or above
+- Node.js 8 or above
+
+
 Installation
 ------------------------------------------------------------------------------
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,126 +1,67 @@
-/* eslint-env node */
-module.exports = {
-  useYarn: true,
-  scenarios: [
-    {
-      name: 'ember-2.0',
-      bower: {
-        dependencies: {
-          ember: '~2.0.0',
+'use strict';
+
+const getChannelURL = require('ember-source-channel-url');
+
+module.exports = function() {
+  return Promise.all([
+    getChannelURL('release'),
+    getChannelURL('beta'),
+    getChannelURL('canary')
+  ]).then((urls) => {
+    return {
+      useYarn: true,
+      scenarios: [
+        {
+          name: 'ember-lts-3.4',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.4.0'
+            }
+          }
         },
-      },
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.18.0',
-          'ember-source': null,
+        {
+          name: 'ember-lts-3.8',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.8.0'
+            }
+          }
         },
-      },
-    },
-    {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#lts-2-4',
+        {
+          name: 'ember-release',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[0]
+            }
+          }
         },
-        resolutions: {
-          ember: 'lts-2-4',
+        {
+          name: 'ember-beta',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[1]
+            }
+          }
         },
-      },
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.18.0',
-          'ember-source': null,
+        {
+          name: 'ember-canary',
+          npm: {
+            devDependencies: {
+              'ember-source': urls[2]
+            }
+          }
         },
-      },
-    },
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#lts-2-8',
+        // The default `.travis.yml` runs this scenario via `npm test`,
+        // not via `ember try`. It's still included here so that running
+        // `ember try:each` manually or from a customized CI config will run it
+        // along with all the other scenarios.
+        {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {}
+          }
         },
-        resolutions: {
-          'ember-data': '~2.18.0',
-          ember: 'lts-2-8',
-        },
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null,
-        },
-      },
-    },
-    {
-      name: 'ember-lts-2.12',
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.18.0',
-          'ember-source': '~2.12.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.16',
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.18.0',
-          'ember-source': '~2.16.0'
-        }
-      }
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
-          'ember': 'release'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-default',
-      npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+      ]
+    };
+  });
 };

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-load-initializers": "^2.0.0",
     "ember-resolver": "^5.1.3",
     "ember-source": "~3.9.1",
+    "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.1.0",
     "eslint": "^5.16.0",
     "eslint-plugin-ember": "^6.4.1",


### PR DESCRIPTION
Supporting the latest two LTS releases here should be sufficient. If people need support for older Ember.js versions they can use the older `ember-mocha` releases.