### PR TITLE
[WIP] fixes for ember-source@3.13

### DIFF
--- a/addon-test-support/ember-mocha/setup-test.js
+++ b/addon-test-support/ember-mocha/setup-test.js
@@ -6,10 +6,8 @@ import {
   setupContext,
   teardownContext
 } from '@ember/test-helpers';
-import { assign, merge } from '@ember/polyfills';
 import { resolve } from 'rsvp';
 
-const _assign = assign || merge;
 
 function chainHooks(hooks, context) {
   return hooks.reduce((promise, fn) => promise.then(fn.bind(context)), resolve());
@@ -25,12 +23,10 @@ function setupPauseTest(context) {
 }
 
 export default function setupTest(options) {
-  let originalContext;
   let beforeEachHooks = [];
   let afterEachHooks = [];
 
   beforeEach(function() {
-    originalContext = _assign({}, this);
 
     return setupContext(this, options)
       .then(() => setupPauseTest(this))
@@ -39,18 +35,7 @@ export default function setupTest(options) {
 
   afterEach(function() {
     return chainHooks(afterEachHooks, this)
-      .then(() => teardownContext(this))
-      .then(() => {
-        // delete any extraneous properties
-        for (let key in this) {
-          if (!(key in originalContext)) {
-            delete this[key];
-          }
-        }
-
-        // copy over the original values
-        _assign(this, originalContext);
-      });
+      .then(() => teardownContext(this));
   });
 
   /**

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -39,6 +39,18 @@ describe('setupRenderingTest', function() {
       expect(this.element.textContent.trim()).to.equal('Pretty Color: green');
     });
 
+    it('should pass when using this.set ', async function() {
+      this.set('name', 'red');
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: red');
+    });
+
+    it('passes when using standard setters', async function() {
+      this.name = 'red';
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: red');
+    });
+
     it('renders a second time without', async function() {
       await render(hbs`{{pretty-color name=name}}`);
       expect(this.element.textContent.trim()).to.equal('Pretty Color:');

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -39,7 +39,7 @@ describe('setupRenderingTest', function() {
       expect(this.element.textContent.trim()).to.equal('Pretty Color: green');
     });
 
-    it('should pass when using this.set ', async function() {
+    it('fails when using this.set (but should pass)', async function() {
       this.set('name', 'red');
       await render(hbs`{{pretty-color name=name}}`);
       expect(this.element.textContent.trim()).to.equal('Pretty Color: red');

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -45,6 +45,7 @@ describe('setupRenderingTest', function() {
       expect(this.element.textContent.trim()).to.equal('Pretty Color: red');
     });
 
+    // TODO following test fails because of name being a tracked property. Assert this failure?
     it('passes when using standard setters', async function() {
       this.name = 'red';
       await render(hbs`{{pretty-color name=name}}`);
@@ -52,6 +53,7 @@ describe('setupRenderingTest', function() {
     });
 
     it('renders a second time without', async function() {
+      this.set('name', '');
       await render(hbs`{{pretty-color name=name}}`);
       expect(this.element.textContent.trim()).to.equal('Pretty Color:');
     });


### PR DESCRIPTION
See the discussion in #431. I think this may be the underlying issue in #430 and blocking https://github.com/TryGhost/Ghost-Admin/pull/1335. 

Without the changes to `setup-test.js` the first test I added fails. I observed this in my application as well. It appeared that properties set on `this` in a `beforeEach` no longer persisted between tests. 
Upon removing the caching behavior in `setup-test.js` the first test passes as I expect. I would like to understand why this is the case though.
- Why do we copy test context properties using `assign` or `merge`? Or what purpose did that logic serve when introduced?

The second test I added  fails with a helpful message about `name` being a tracked property. I would expect this to fail so should I assert that it does fail?