### PR TITLE
Remove check for ember-cli-htmlbars-inline-precompile

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,6 @@ module.exports = {
       console.warn('\nIt looks like you are using "ember-cli-qunit" which can cause issues with "ember-cli-mocha", please remove this package.\n');
       process.exit(1);
     }
-    if (packages.indexOf('ember-cli-htmlbars-inline-precompile') === -1) {
-      console.warn('\nIt looks like you\'re not on ember-cli 1.13, which includes ember-cli-htmlbars-inline-precompile by default. Please run: ember install ember-cli-htmlbars-inline-precompile.\n');
-      process.exit(1);
-    }
   },
 
   included() {


### PR DESCRIPTION
Removed `ember-cli-htmlbars-inline-precompile package` check because:

- it breaks now that `ember-cli-htmlbars-inline-precompile` has been deprecated and rolled into `ember-cli-htmlbars@4.0.3`
- it appears to target very old projects on `ember-cli` prior to v1.13 but these days `ember-mocha` requires `ember-cli@2.13` or later

There could be a rationale for keeping this check and updating it not to trigger when the project is using `ember-cli-htmlbars@4.0.3` or later. Not sure if it's worth it though.