### PR TITLE
fix 430, support ember-source 3.13

### DIFF
--- a/addon-test-support/ember-mocha/setup-test.js
+++ b/addon-test-support/ember-mocha/setup-test.js
@@ -47,8 +47,10 @@ export default function setupTest(options) {
       // on the test context with what was
       // there from internal test setup
       Object.keys(this).filter(key => !isInternalKey(key))
-        .forEach(key => delete this[key]);
-      // delete the owner instance
+        .forEach(key => this.set(key, null));
+
+      // we must forcibly remove owner
+      // and cannot clear it using `this.set`
       delete this.owner;
     };
     return chainHooks(afterEachHooks, this)

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -43,6 +43,13 @@ describe('setupRenderingTest', function() {
       await render(hbs`{{pretty-color name=name}}`);
       expect(this.element.textContent.trim()).to.equal('Pretty Color:');
     });
+
+    it('renders a third time with', async function() {
+      this.set('name', 'red');
+      expect(this.name).to.equal('red');
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: red');
+    });
   });
 
   describe('hooks API', function() {

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -52,6 +52,13 @@ describe('setupRenderingTest', function() {
       await render(hbs`{{pretty-color name=name}}`);
       expect(this.element.textContent.trim()).to.equal(`Pretty Color: ${value}`);
     });
+
+    it('can set properties using dot notation that have been tracked in prior tests', async function() {
+      this.name = 'indigo';
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: indigo');
+    });
+
   });
 
   describe('hooks API', function() {

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -45,10 +45,12 @@ describe('setupRenderingTest', function() {
     });
 
     it('renders a third time with', async function() {
-      this.set('name', 'red');
-      expect(this.name).to.equal('red');
+      let value = 'red';
+      this.set('name', value);
+      expect(this.get('name')).to.equal(value);
+      expect(this.name).to.equal(value);
       await render(hbs`{{pretty-color name=name}}`);
-      expect(this.element.textContent.trim()).to.equal('Pretty Color: red');
+      expect(this.element.textContent.trim()).to.equal(`Pretty Color: ${value}`);
     });
   });
 

--- a/tests/unit/setup-test-test.js
+++ b/tests/unit/setup-test-test.js
@@ -37,6 +37,11 @@ describe('setupTest', function() {
       this.set('foo', 'bar');
       expect(this.get('foo')).to.equal('bar');
     });
+
+    it('resets properties between tests', function() {
+      expect(this.foo).to.equal(undefined);
+    });
+
   });
 
   describe('pauseTest/resumeTest', function() {

--- a/tests/unit/setup-test-test.js
+++ b/tests/unit/setup-test-test.js
@@ -37,11 +37,6 @@ describe('setupTest', function() {
       this.set('foo', 'bar');
       expect(this.get('foo')).to.equal('bar');
     });
-
-    it('resets properties between tests', function() {
-      expect(this.foo).to.equal(undefined);
-    });
-
   });
 
   describe('pauseTest/resumeTest', function() {


### PR DESCRIPTION
This PR fixes #430 and adds support for ember-source@3.13.x.
See #450 for the background conversation and root cause analysis (thanks to @simonihmig 😄 ).

I do a couple things here.
1. add a failing case for #430, (#431)
2. refactored the state removal logic to be more explict and only clean up keys that a user has set. While debugging I found it somewhat confusing we were cleaning up all properties on the test context. e.g. `set`, `get`, and others. I changed it to only tear down user defined keys and `owner`.
3. We need to change the main property clean up to `this.set('someKey', null)`. This properly delegates the setter behavior for the tracked property logic of ember-source >= 3.13

Change 2 is optional so I can rebase with only 1 and 3 if is preferred.