### PR TITLE
Use a disposable object to serve as context for Ember test helpers

### DIFF
--- a/addon-test-support/ember-mocha/ember-test-context.js
+++ b/addon-test-support/ember-mocha/ember-test-context.js
@@ -1,0 +1,43 @@
+export default class EmberTestContext {
+  constructor(mochaContext) {
+    this.element = null;
+    this.mochaContext = mochaContext;
+  }
+
+  unknownProperty(key) {
+    return this.mochaContext[key];
+  }
+
+  setUnknownProperty(key, value) {
+    this.defineOnMochaContext(key);
+    this.mochaContext[key] = value;
+    return value;
+  }
+
+  syncProperties() {
+    const ignoredProperties = [
+      'mochaContext',
+      'unknownProperty',
+      'setUnknownProperty',
+      'defineOnMochaContext',
+      'syncProperties'
+    ];
+    for (const key in this) {
+      if (!ignoredProperties.includes(key)) { this.defineOnMochaContext(key); }
+    }
+  }
+
+  defineOnMochaContext(key) {
+    const emberContext = this;
+    if (typeof this[key] === 'function') {
+      this.mochaContext[key] = function() { return emberContext[key].apply(emberContext, arguments); };
+    } else {
+      Object.defineProperty(this.mochaContext, key, {
+        configurable: true,
+        enumerable: true,
+        get() { return emberContext[key]; },
+        set(value) { emberContext[key] = value; }
+      });
+    }
+  }
+}

--- a/addon-test-support/ember-mocha/setup-application-test.js
+++ b/addon-test-support/ember-mocha/setup-application-test.js
@@ -1,4 +1,5 @@
 import {
+  getContext,
   setupApplicationContext,
   teardownApplicationContext
 } from '@ember/test-helpers';
@@ -8,10 +9,10 @@ export default function setupApplicationTest(options) {
   let hooks = setupTest(options);
 
   hooks.beforeEach(function() {
-    return setupApplicationContext(this);
+    return setupApplicationContext(getContext());
   });
   hooks.afterEach(function() {
-    return teardownApplicationContext(this);
+    return teardownApplicationContext(getContext());
   });
 
   return hooks;

--- a/addon-test-support/ember-mocha/setup-rendering-test.js
+++ b/addon-test-support/ember-mocha/setup-rendering-test.js
@@ -1,4 +1,5 @@
 import {
+  getContext,
   setupRenderingContext,
   teardownRenderingContext
 } from '@ember/test-helpers';
@@ -8,10 +9,10 @@ export default function setupRenderingTest(options) {
   let hooks = setupTest(options);
 
   hooks.beforeEach(function() {
-    return setupRenderingContext(this);
+    return setupRenderingContext(getContext());
   });
   hooks.afterEach(function() {
-    return teardownRenderingContext(this);
+    return teardownRenderingContext(getContext());
   });
 
   return hooks;

--- a/tests/unit/setup-rendering-test-test.js
+++ b/tests/unit/setup-rendering-test-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-mocha';
 import { describe, it, beforeEach } from 'mocha';
 import { expect } from 'chai';
 import hbs from 'htmlbars-inline-precompile';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 const PrettyColor = Component.extend({
@@ -12,13 +12,16 @@ const PrettyColor = Component.extend({
   attributeBindings: ['style'],
   style: computed('name', function() {
     return 'color: ' + this.get('name') + ';';
-  })
+  }),
+  actions: {
+    paintItBlack() { this.set('name', 'black'); }
+  }
 });
 
 function setupRegistry(owner) {
   owner.register('component:x-foo', Component.extend());
   owner.register('component:pretty-color', PrettyColor);
-  owner.register('template:components/pretty-color', hbs`Pretty Color: <span class="color-name">{{name}}</span>`);
+  owner.register('template:components/pretty-color', hbs`Pretty Color: <button {{action "paintItBlack"}}><span class="color-name">{{name}}</span></button>`);
 }
 
 describe('setupRenderingTest', function() {
@@ -39,9 +42,39 @@ describe('setupRenderingTest', function() {
       expect(this.element.textContent.trim()).to.equal('Pretty Color: green');
     });
 
+    it('renders when using standard setters', async function() {
+      this.name = 'red';
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: red');
+    });
+
     it('renders a second time without', async function() {
       await render(hbs`{{pretty-color name=name}}`);
       expect(this.element.textContent.trim()).to.equal('Pretty Color:');
+    });
+
+    it('renders a third time with', async function() {
+      this.set('name', 'blue');
+      expect(this.get('name')).to.equal('blue');
+      await render(hbs`{{pretty-color name=name}}`);
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: blue');
+    });
+
+    it('picks up changes to variables set on the context', async function() {
+      this.set('name', 'pink');
+      await render(hbs`{{pretty-color name=name}}`);
+      await click('button');
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: black');
+      expect(this.get('name')).to.equal('black');
+      expect(this.name).to.equal('black');
+    });
+
+    it('picks up changes to variables set on the context with a standard setter', async function() {
+      this.name = 'pink';
+      await render(hbs`{{pretty-color name=name}}`);
+      await click('button');
+      expect(this.element.textContent.trim()).to.equal('Pretty Color: black');
+      expect(this.name).to.equal('black');
     });
   });
 


### PR DESCRIPTION
### Summary
Because Ember 3.13 introduces an inaccessible WeakMap for framework-provided setters (to support tracked properties) keyed off of the owning object, the contexts used in Ember tests _need_ to be disposable objects, lest a stale setter be used for a property sharing the same name with one from a previous test. To balance the ergonomics of Mocha, this change introduces such a disposable object, which gets passed to the various `@ember/test-helper`-provided setup methods, and then forwarding attributes are set up and torn down on `this` that provide transparent access to the disposable context.

One drawback to this approach is that attributes added to the Ember test context without invoking `setUnknownProperty()` will be unavailable on the Mocha context unless an empty value is added to the Ember context before setup; there is already an example of this in the application test function `visit()`, which sets `element` on the context without it having been added to the context as part of `setupApplicationContext()`. This solution would necessitate such attributes be added to the disposable context object before forwarding is set up (as is done already with `element`). This is somewhat mitigated by adding `unknownProperty()` and `setUnknownProperty()` to the EmberTestContext class, as it allows templates to access attributes which may have been set on the Mocha context without using `this.set`, but it's still not ideal in that the calling getter/setter must respect the `unknownProperty()/setUnknownProperty()` methods, which a native getter/setter will not.

This PR would be an alternate solution from #460 to address #430 (and indeed two of the added tests were pulled almost directly from #460 and #450; the other two represent what is perhaps not _best_ practices, but they validate that it continues to work how it did previously, at any rate). I'd done some digging on my own, but I was glad to have my suspicions confirmed by @simonihmig in the discussion on #450. Thanks! 🙂 